### PR TITLE
Update API headers to specify v3

### DIFF
--- a/bug_crowd/client.py
+++ b/bug_crowd/client.py
@@ -18,7 +18,7 @@ class BugcrowdClient(object):
         self.session = FuturesSession(max_workers=5)
         self.base_uri = 'https://api.bugcrowd.com/'
         self.session.headers.update({
-            'Accept': 'application/vnd.bugcrowd.v2+json',
+            'Accept': 'application/vnd.bugcrowd.v3+json',
             'Authorization': 'Token %s' % self._api_token,
             'user-agent': 'Bugcrowd Python Client',
         })


### PR DESCRIPTION
API v2 is set for removal on August 12.

I haven't tested this change extensively, but the rest of the library looks to be compatible with API v3.