### PR TITLE
Sem-ver: bugfix Update the create submission example to use utcnow instead of now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pip install bug-crowd-api-client
     submission_fields = {
         'substate': 'unresolved',
         'title': 'Example submission',
-        'submitted_at': datetime.datetime.now(),
+        'submitted_at': datetime.datetime.utcnow(),
         'description_markdown': 'Example description',
     }
 


### PR DESCRIPTION
Please note that the bugcrowd api doesn't currently accept submissions with a submitted_at field ahead of the current (utc) time.

Signed-off-by: David Black <dblack@atlassian.com>