### PR TITLE
Add a new feature to fetch comments on a submission.

### DIFF
--- a/bug_crowd/client.py
+++ b/bug_crowd/client.py
@@ -64,11 +64,9 @@ class BugcrowdClient(object):
                 for submission in data['submissions']:
                     yield submission
 
-    def get_comments(self, submission):
+    def get_comments_for_submission(self, submission):
         """ Yields comments for the given submission or submission uuid. """
-        submission_uuid = _get_uuid(submission)
-        comments_uri = self.get_api_uri(
-            'submissions/%s/comments' % submission_uuid)
+        comments_uri = self.get_api_uri_for_submission_comments(submission)
         resp = self.session.get(comments_uri).result()
         resp.raise_for_status()
         return resp.json()

--- a/bug_crowd/client.py
+++ b/bug_crowd/client.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from requests_futures.sessions import FuturesSession
 import six
 from six.moves.urllib.parse import quote as url_quote
@@ -63,6 +64,15 @@ class BugcrowdClient(object):
                 for submission in data['submissions']:
                     yield submission
 
+    def get_comments(self, submission):
+        """ Yields comments for the given submission or submission uuid. """
+        submission_uuid = _get_uuid(submission)
+        comments_uri = self.get_api_uri(
+            'submissions/%s/comments' % submission_uuid)
+        resp = self.session.get(comments_uri).result()
+        resp.raise_for_status()
+        return resp.json()
+
     def get_api_uri(self, path):
         """ Returns the full api uri for the given path. """
         return self.base_uri + url_quote(path)
@@ -78,6 +88,12 @@ class BugcrowdClient(object):
         """ Returns the uri for the given submission or submission uuid. """
         submission_uuid = _get_uuid(submission)
         return self.get_api_uri('submissions/%s' % submission_uuid)
+
+    def get_api_uri_for_submission_comments(self, submission):
+        """ Returns the uri for comments on the given submission or
+        submission uuid.
+        """
+        return self.get_api_uri_for_submission(submission) + '/comments'
 
     def create_submission(self, bounty, submission_fields):
         """ Returns a future request creating a submission in the
@@ -109,7 +125,7 @@ class BugcrowdClient(object):
     def comment_on_submission(self, submission, comment_text,
                               comment_type='note'):
         """ Returns a future request commenting on the given submission. """
-        uri = self.get_api_uri_for_submission(submission) + '/comments'
+        uri = self.get_api_uri_for_submission_comments(submission)
         payload = {
             'comment': {
                 'body_markdown': comment_text,

--- a/bug_crowd/client.py
+++ b/bug_crowd/client.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from requests_futures.sessions import FuturesSession
 import six
 from six.moves.urllib.parse import quote as url_quote

--- a/bug_crowd/test.py
+++ b/bug_crowd/test.py
@@ -143,13 +143,13 @@ class BugcrowdClientTest(unittest.TestCase):
 
     @mock.patch.object(requests.Session, 'get')
     def test_get_comments_for_submission(self, mocked_method):
-        """ tests that the get_comments method works as expected.
+        """ tests that the get_comments_for_submission method works as expected.
         """
         submission = get_example_submission()
         uri = self.client.get_api_uri_for_submission_comments(submission)
         expected_comments = [self._comments]
         setup_example_comments_response(mocked_method, expected_comments)
-        self.assertEqual(self.client.get_comments(submission),
+        self.assertEqual(self.client.get_comments_for_submission(submission),
                          expected_comments)
         mocked_method.assert_called_once_with(uri)
 

--- a/bug_crowd/test.py
+++ b/bug_crowd/test.py
@@ -45,7 +45,6 @@ class BugcrowdClientTest(unittest.TestCase):
         self.client = BugcrowdClient(self.api_token)
         self._bounty = get_example_bounty()
         self._comments = get_example_comments()
-        self._submission = get_example_submission()
 
     def test_accept_header(self):
         """ tests that the accept header of the session is correct. """
@@ -308,31 +307,31 @@ def get_example_submission(**kwargs):
 
 def get_example_comments():
     """ returns example comments on a submission. """
+    user1 = 24601
+    user2 = 42
+    user_ids_to_uuids = {user1: uuid.uuid4(), user2: uuid.uuid4()}
+    user_ids_to_names = {user1: 'Atlassian_bot', user2: 'Cool_McJones_ASE'}
     return {'tester_messages': [
         {
             'body_markdown': 'Issue was fixed!',
             'created_at': '2018-05-08T08:33:24.732Z',
             'file_attachments_count': 0,
-            'user_id': 24601,
-            'uuid':
-                '92ca4503-a33f-4e89-9934-ba5a12044c20',
+            'user_id': user1,
+            'uuid': uuid.uuid4(),
             'identity': {
-                'uuid':
-                    '3337a640-d1f6-4520-9864-64809c2ace02',
-                'name': 'Atlassian_bot',
+                'uuid': user_ids_to_uuids[user1],
+                'name': user_ids_to_names[user1],
                 'type': 'crowdcontrol_user'}
         },
         {
             'body_markdown': 'Cool! We`ve paid you.',
             'created_at': '2018-03-19T06:25:09.705Z',
             'file_attachments_count': 0,
-            'user_id': 24601,
-            'uuid':
-                'bce166b5-87bf-4f0d-9816-30ff487bd889',
+            'user_id': user1,
+            'uuid': uuid.uuid4(),
             'identity': {
-                'uuid':
-                    '3337a640-d1f6-4520-9864-64809c2ace02',
-                'name': 'Atlassian_bot',
+                'uuid': user_ids_to_uuids[user1],
+                'name': user_ids_to_names[user1],
                 'type': 'crowdcontrol_user'}
         }
     ],
@@ -340,11 +339,12 @@ def get_example_comments():
             {
                 'body_markdown': 'I verified the issue!',
                 'created_at': '2018-03-15T19:54:39.714Z',
-                'file_attachments_count': 0, 'user_id': 42,
-                'uuid': '289d0162-6312-42ab-b509-efe59ba9a258',
+                'file_attachments_count': 0,
+                'user_id': user2,
+                'uuid': uuid.uuid4(),
                 'identity': {
-                    'uuid': 'ae872cd8-6ddc-468e-adb6-e943fed1246a',
-                    'name': 'coolmcjones_bugcrowd',
+                    'uuid': user_ids_to_uuids[user2],
+                    'name': user_ids_to_names[user2],
                     'type': 'bugcrowd_ase'}
             }
         ]

--- a/bug_crowd/test.py
+++ b/bug_crowd/test.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import datetime
 import unittest
 import uuid
@@ -7,7 +6,7 @@ import mock
 import requests
 from six.moves.urllib.parse import quote as url_quote
 
-from client import (
+from .client import (
     BugcrowdClient,
     get_uri_for_bounty_submission,
     _convert_datetime_to_submission_creation_format,
@@ -44,7 +43,6 @@ class BugcrowdClientTest(unittest.TestCase):
         self.api_token = 'api-token-%s' % uuid.uuid4()
         self.client = BugcrowdClient(self.api_token)
         self._bounty = get_example_bounty()
-        self._comments = get_example_comments()
 
     def test_accept_header(self):
         """ tests that the accept header of the session is correct. """
@@ -147,7 +145,7 @@ class BugcrowdClientTest(unittest.TestCase):
         """
         submission = get_example_submission()
         uri = self.client.get_api_uri_for_submission_comments(submission)
-        expected_comments = [self._comments]
+        expected_comments = [get_example_comments()]
         setup_example_comments_response(mocked_method, expected_comments)
         self.assertEqual(self.client.get_comments_for_submission(submission),
                          expected_comments)

--- a/bug_crowd/test.py
+++ b/bug_crowd/test.py
@@ -61,7 +61,7 @@ class BugcrowdClientTest(unittest.TestCase):
             as expected.
         """
         expected_uri = self.client.base_uri + (
-                'bounties/%s/submissions' % url_quote(self._bounty['uuid']))
+            'bounties/%s/submissions' % url_quote(self._bounty['uuid']))
         uri = self.client.get_api_uri_for_bounty_submissions(self._bounty)
         self.assertEqual(uri, expected_uri)
 
@@ -71,7 +71,7 @@ class BugcrowdClientTest(unittest.TestCase):
         """
         submission = get_example_submission()
         expected_uri = self.client.base_uri + (
-                'submissions/%s' % url_quote(submission['uuid']))
+            'submissions/%s' % url_quote(submission['uuid']))
         self.assertEqual(
             self.client.get_api_uri_for_submission(submission), expected_uri)
 


### PR DESCRIPTION
This feature lets you fetch an issue's comments via the /submissions/(uuid)/comments URI:
[https://docs.bugcrowd.com/reference#view-comments](https://docs.bugcrowd.com/reference#view-comments)